### PR TITLE
fix: 函数名错误

### DIFF
--- a/docs/design/Strategy Pattern.md
+++ b/docs/design/Strategy Pattern.md
@@ -86,7 +86,7 @@ registerForm.onsubmit = function(){
 此处也可以使用策略模式进行重构校验，第一步确定不变的内容，即策略规则对象，如下：
 
 ```js
-var strategy = {
+var strategys = {
     isNotEmpty: function(value,errorMsg) {
         if(value === '') {
             return errorMsg;


### PR DESCRIPTION
https://vue3js.cn/interview/design/Strategy%20Pattern.html#%E4%BA%8C%E3%80%81%E4%BD%BF%E7%94%A8
Validator类使用 strategys[strategy].apply(dom,str)， 但是上面定义的函数名字为strategy