### PR TITLE
fix: 订阅-发布：notify通知函数，并没有给订阅者订阅类型的所有信息

### DIFF
--- a/docs/design/Observer  Pattern.md
+++ b/docs/design/Observer  Pattern.md
@@ -117,7 +117,7 @@ class PubSub {
   notify(type) {
     const messages = this.messages[type];
     const subscribers = this.listeners[type] || [];
-    subscribers.forEach((cb, index) => cb(messages[index]));
+    subscribers.forEach((cb) => cb(messages));
   }
 }
 ```


### PR DESCRIPTION
https://vue3js.cn/interview/design/Observer%20%20Pattern.html#%E4%BA%8C%E3%80%81%E5%8F%91%E5%B8%83%E8%AE%A2%E9%98%85%E6%A8%A1%E5%BC%8F
订阅-发布：notify通知函数，并没有返回给订阅者订阅类型的所有信息
cb(message[index]), 只拿到一个订阅类型的信息
```js
  // 通知
  notify(type) {
    const messages = this.messages[type];
    const subscribers = this.listeners[type] || [];
    subscribers.forEach((cb, index) => cb(messages[index]));
  }
```

不应该是订阅者获取到订阅者订阅的所有信息吗
```js
  // 通知
  notify(type) {
    const messages = this.messages[type];
    const subscribers = this.listeners[type] || [];
    subscribers.forEach((cb) => cb(messages));
  }
```