### PR TITLE
fix 数组扩展运算符的例子

### DIFF
--- a/docs/es6/array.md
+++ b/docs/es6/array.md
@@ -64,8 +64,8 @@ const arr3 = ['d', 'e'];
 const arr1 = ['a', 'b',[1,2]];
 const arr2 = ['c'];
 const arr3  = [...arr1,...arr2]
-arr[1][0] = 9999 // 修改arr1里面数组成员值
-console.log(arr[3]) // 影响到arr3,['a','b',[9999,2],'c']
+arr1[2][0] = 9999 // 修改arr1里面数组成员值
+console.log(arr3) // 影响到arr3,['a','b',[9999,2],'c']
 ```
 
 扩展运算符可以与解构赋值结合起来，用于生成数组


### PR DESCRIPTION
示例中的代码无法运行, arr并不存在