### PR TITLE
fix: 修复快速排序代码中的笔误

### DIFF
--- a/docs/algorithm/quickSort.md
+++ b/docs/algorithm/quickSort.md
@@ -55,7 +55,7 @@ function quickSort (arr) {
     }
     return [...rec(left), mid, ...rec(right)]
   }
-  return res(arr)
+  return rec(arr)
 };
 ```
 


### PR DESCRIPTION
示例最下方有笔误return rec(arr)错写成了return res(arr)
<img width="757" alt="image" src="https://github.com/febobo/web-interview/assets/20721540/458b247b-9e69-4dd9-923b-292a70dc51d2">

修改为return rec(arr)后，使用测试数据成功。
var arr = [3, 1, 4, 5, 2, 8, 22, 12, 32, 24]
quickSort(arr)
<img width="475" alt="image" src="https://github.com/febobo/web-interview/assets/20721540/8d2e7607-2466-4d5c-9ff5-51071424379f">
